### PR TITLE
VTX-4260 Remove GenerateEsApiKey

### DIFF
--- a/com/coralogix/users/v1/user_settings.proto
+++ b/com/coralogix/users/v1/user_settings.proto
@@ -7,7 +7,7 @@ import "google/protobuf/wrappers.proto";
 message UserSettings {
   google.protobuf.StringValue user_id = 1;
   google.protobuf.StringValue api_key = 2;
-  google.protobuf.StringValue es_api_key = 3;
+  google.protobuf.StringValue es_api_key = 3 [deprecated = true];
   google.protobuf.StringValue teams_api_key = 4;
   google.protobuf.StringValue data = 5;
 }

--- a/com/coralogix/users/v1/user_settings_service.proto
+++ b/com/coralogix/users/v1/user_settings_service.proto
@@ -29,13 +29,6 @@ service UserSettingsService {
     };
   }
 
-  rpc GenerateNewEsApiKeyForUser(GenerateNewEsApiKeyForUserRequest) returns (GenerateNewEsApiKeyForUserResponse) {
-    option (audit_log_description).description = "generate new es-api key for user";
-    option (google.api.http) = {
-      post: "/api/v1/user/settings/es_api_key"
-    };
-  }
-
   rpc GenerateNewTeamsApiKeyForUser(GenerateNewTeamsApiKeyForUserRequest) returns (GenerateNewTeamsApiKeyForUserResponse) {
     option (audit_log_description).description = "generate new team-api key for user";
     option (google.api.http) = {


### PR DESCRIPTION
- There is no usage of GenerateNewEsApiKeyForUser, we can remove it. The es api key now is managed through permissions service
- Deprecated user_settings.es_api_key - all services should fetch it directly from permission service.