### PR TITLE
VTX-4260 Remove GenerateEsApiKey  [skip-ci]

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -4,7 +4,5 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    branch: main
-    commit: 2b8053e441304030a90dad3b3486d7ff
-    digest: b1-2CZhPz7z48pjpfhSWmJkYuzHqHCU7zfHza6a0hYv_dw=
-    create_time: 2021-11-08T15:08:59.319331Z
+    commit: a86849a25cc04f4dbe9b15ddddfbc488
+    digest: shake256:e19143328f8cbfe13fc226aeee5e63773ca494693a72740a7560664270039a380d94a1344234b88c7691311460df9a9b1c2982190d0a2612eae80368718e1943

--- a/com/coralogix/users/v1/user_settings.proto
+++ b/com/coralogix/users/v1/user_settings.proto
@@ -7,7 +7,7 @@ import "google/protobuf/wrappers.proto";
 message UserSettings {
   google.protobuf.StringValue user_id = 1;
   google.protobuf.StringValue api_key = 2;
-  google.protobuf.StringValue es_api_key = 3;
+  google.protobuf.StringValue es_api_key = 3 [deprecated = true];
   google.protobuf.StringValue teams_api_key = 4;
   google.protobuf.StringValue data = 5;
 }

--- a/com/coralogix/users/v1/user_settings_service.proto
+++ b/com/coralogix/users/v1/user_settings_service.proto
@@ -29,13 +29,6 @@ service UserSettingsService {
     };
   }
 
-  rpc GenerateNewEsApiKeyForUser(GenerateNewEsApiKeyForUserRequest) returns (GenerateNewEsApiKeyForUserResponse) {
-    option (audit_log_description).description = "generate new es-api key for user";
-    option (google.api.http) = {
-      post: "/api/v1/user/settings/es_api_key"
-    };
-  }
-
   rpc GenerateNewTeamsApiKeyForUser(GenerateNewTeamsApiKeyForUserRequest) returns (GenerateNewTeamsApiKeyForUserResponse) {
     option (audit_log_description).description = "generate new team-api key for user";
     option (google.api.http) = {


### PR DESCRIPTION
- There is no usage of GenerateNewEsApiKeyForUser, we can remove it. The es api key now is managed through permissions service
- Deprecated user_settings.es_api_key - all services should fetch it directly from permission service.