### PR TITLE
VTX-4592 Remove generate teams api key

### DIFF
--- a/com/coralogix/users/v1/user_settings_service.proto
+++ b/com/coralogix/users/v1/user_settings_service.proto
@@ -28,13 +28,6 @@ service UserSettingsService {
     };
   }
 
-  rpc GenerateNewTeamsApiKeyForUser(GenerateNewTeamsApiKeyForUserRequest) returns (GenerateNewTeamsApiKeyForUserResponse) {
-    option (audit_log_description).description = "generate new team-api key for user";
-    option (google.api.http) = {
-      post: "/api/v1/user/settings/teams_api_key"
-    };
-  }
-
   rpc GetAllEmailFilters(GetAllEmailFiltersRequest) returns (GetAllEmailFiltersResponse) {
     option (audit_log_description).description = "get all email filters";
     option (google.api.http) = {
@@ -108,12 +101,6 @@ message GenerateNewApiKeyForUserResponse{
 message GenerateNewEsApiKeyForUserRequest{}
 
 message GenerateNewEsApiKeyForUserResponse{
-  UserSettings user_settings = 1;
-}
-
-message GenerateNewTeamsApiKeyForUserRequest{}
-
-message GenerateNewTeamsApiKeyForUserResponse{
   UserSettings user_settings = 1;
 }
 


### PR DESCRIPTION
All services now talk directly with permissions service to manage teams api key, we don't need teams api key management api in users-service anymore